### PR TITLE
Update namespace and module name

### DIFF
--- a/Block/Checkout/Success.php
+++ b/Block/Checkout/Success.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace qbo\PayPalMX\Block\Checkout;
+namespace Qbo\PayPalMX\Block\Checkout;
 
 class Success extends \Magento\Checkout\Block\Onepage\Success
 {

--- a/Block/Express/InContext/Minicart/Button.php
+++ b/Block/Express/InContext/Minicart/Button.php
@@ -3,7 +3,7 @@
  * Copyright © 2013-2017 Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-namespace qbo\PayPalMX\Block\Express\InContext\Minicart;
+namespace Qbo\PayPalMX\Block\Express\InContext\Minicart;
 
 use Magento\Paypal\Block\Express\InContext\Minicart\Button as MinicartButton;
 

--- a/Block/Express/InContext/Minicart/Button.php
+++ b/Block/Express/InContext/Minicart/Button.php
@@ -14,6 +14,6 @@ class Button extends MinicartButton
 {
                 
     public function getImageUrlButtonMx(){
-        return $this->getViewFileUrl('qbo_PayPalMX::img/buttonPpMx.png');
+        return $this->getViewFileUrl('Qbo_PayPalMX::img/buttonPpMx.png');
     }
 }

--- a/Controller/Express/Start.php
+++ b/Controller/Express/Start.php
@@ -5,13 +5,13 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
-namespace qbo\PayPalMX\Controller\Express;
+namespace Qbo\PayPalMX\Controller\Express;
 use Magento\Framework\App\Action\AbstractAction;
 use Magento\Paypal\Controller\Express\AbstractExpress;
 
 /**
  * Extended Start controller to override PayPal Express Config Type and get custom BN Code
- * @see qbo\PayPalMX\Model\Config
+ * @see Qbo\PayPalMX\Model\Config
  *
  * @author kasta
  */
@@ -21,6 +21,6 @@ class Start extends \Magento\Paypal\Controller\Express\Start {
      *
      * @var string
      */
-    protected $_configType = 'qbo\PayPalMX\Model\Config';
+    protected $_configType = 'Qbo\PayPalMX\Model\Config';
 
 }

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-namespace qbo\PayPalMX\Model;
+namespace Qbo\PayPalMX\Model;
 
 /**
  * Config model that is aware of all \Magento\Paypal payment methods

--- a/Model/ConfigProvider.php
+++ b/Model/ConfigProvider.php
@@ -1,5 +1,5 @@
 <?php
-namespace qbo\PayPalMX\Model;
+namespace Qbo\PayPalMX\Model;
 
 use Magento\Checkout\Model\ConfigProviderInterface;
 use Magento\Framework\UrlInterface;

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
             "registration.php"
         ],
         "psr-4": {
-            "qbo\\PayPalMX\\": ""
+            "Qbo\\PayPalMX\\": ""
         }
     }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -19,7 +19,7 @@
  *
  * @author Tadeo Barranco <tadeo@qbo.tech>
  * @category Qbo
- * @package qbo\PayPalMX\
+ * @package Qbo\PayPalMX\
  *
  */
 -->

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -13,6 +13,6 @@
         </arguments>
     </type>
     
-    <preference for="Magento\Paypal\Block\Express\InContext\Minicart\Button" type="qbo\PayPalMX\Block\Express\InContext\Minicart\Button" />
-    <preference for="Magento\Paypal\Controller\Express\Start" type="qbo\PayPalMX\Controller\Express\Start" />
+    <preference for="Magento\Paypal\Block\Express\InContext\Minicart\Button" type="Qbo\PayPalMX\Block\Express\InContext\Minicart\Button" />
+    <preference for="Magento\Paypal\Controller\Express\Start" type="Qbo\PayPalMX\Controller\Express\Start" />
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -9,7 +9,7 @@
 
     <type name="Magento\Paypal\Block\Express\Shortcut">
         <arguments>
-            <argument name="shortcutTemplate" xsi:type="string">qbo_PayPalMX::express/shortcut.phtml</argument>
+            <argument name="shortcutTemplate" xsi:type="string">Qbo_PayPalMX::express/shortcut.phtml</argument>
         </arguments>
     </type>
     

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -17,7 +17,7 @@
     <type name="Magento\Paypal\Block\Express\InContext\Minicart\Button">
         <arguments>
             <argument name="data" xsi:type="array">
-                <item name="template" xsi:type="string">qbo_PayPalMX::express/in-context/shortcut/button.phtml</item>
+                <item name="template" xsi:type="string">Qbo_PayPalMX::express/in-context/shortcut/button.phtml</item>
             </argument>
         </arguments>
     </type>

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -9,11 +9,11 @@
     <type name="Magento\Checkout\Model\CompositeConfigProvider">
         <arguments>
             <argument name="configProviders" xsi:type="array">
-                <item name="qbo_paypalmx_config_provider" xsi:type="object">qbo\PayPalMX\Model\ConfigProvider</item>
+                <item name="qbo_paypalmx_config_provider" xsi:type="object">Qbo\PayPalMX\Model\ConfigProvider</item>
             </argument>
         </arguments>
     </type>
-    
+
     <type name="Magento\Paypal\Block\Express\InContext\Minicart\Button">
         <arguments>
             <argument name="data" xsi:type="array">
@@ -21,5 +21,5 @@
             </argument>
         </arguments>
     </type>
-    
+
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -24,7 +24,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
-    <module name="qbo_PayPalMX" setup_version="0.0.1">
+    <module name="Qbo_PayPalMX" setup_version="0.0.1">
     	<sequence>
             <module name="Magento_Paypal"/>
             <module name="Magento_Checkout"/>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -19,7 +19,7 @@
  *
  * @author Tadeo Barranco <tadeo@qbo.tech>
  * @category Qbo
- * @package qbo\PayPalMX\
+ * @package Qbo\PayPalMX\
  *
  */
 -->

--- a/registration.php
+++ b/registration.php
@@ -18,7 +18,7 @@
  *
  * @author Tadeo Barranco <tadeo@qbo.tech>
  * @category Qbo
- * @package qbo\PayPalMX\
+ * @package Qbo\PayPalMX\
  *
  */
 

--- a/registration.php
+++ b/registration.php
@@ -24,6 +24,6 @@
 
 \Magento\Framework\Component\ComponentRegistrar::register(
     \Magento\Framework\Component\ComponentRegistrar::MODULE,
-    'qbo_PayPalMX',
+    'Qbo_PayPalMX',
     __DIR__
 );

--- a/view/adminhtml/layout/adminhtml_system_config_edit.xml
+++ b/view/adminhtml/layout/adminhtml_system_config_edit.xml
@@ -19,7 +19,7 @@
  *
  * @author Tadeo Barranco <tadeo@qbo.tech>
  * @category Qbo
- * @package qbo\PayPalMX\
+ * @package Qbo\PayPalMX\
  *
  */
 -->

--- a/view/adminhtml/layout/adminhtml_system_config_edit.xml
+++ b/view/adminhtml/layout/adminhtml_system_config_edit.xml
@@ -25,6 +25,6 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
-        <css src="qbo_PayPalMX::styles.css"/>
+        <css src="Qbo_PayPalMX::styles.css"/>
     </head>
 </page>

--- a/view/adminhtml/web/styles.css
+++ b/view/adminhtml/web/styles.css
@@ -17,7 +17,7 @@
  *
  * @author Tadeo Barranco <tadeo@qbo.tech>
  * @category Qbo
- * @package qbo\PayPalMX\
+ * @package Qbo\PayPalMX\
  *
  */
 .pp-method-express > .entry-edit-head > .config-heading:before { content:url(images/ppmx-alt.png);float:right;}

--- a/view/frontend/layout/checkout_onepage_success.xml
+++ b/view/frontend/layout/checkout_onepage_success.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="order.success.additional.info" label="Order Success Additional Info">
-            <block class="qbo\PayPalMX\Block\Checkout\Success" name="paypal.success.additional" template="qbo_PayPalMX::checkout/success.phtml" cacheable="false" />
+            <block class="Qbo\PayPalMX\Block\Checkout\Success" name="paypal.success.additional" template="qbo_PayPalMX::checkout/success.phtml" cacheable="false" />
         </referenceContainer>
     </body>
 </page>

--- a/view/frontend/layout/checkout_onepage_success.xml
+++ b/view/frontend/layout/checkout_onepage_success.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="order.success.additional.info" label="Order Success Additional Info">
-            <block class="Qbo\PayPalMX\Block\Checkout\Success" name="paypal.success.additional" template="qbo_PayPalMX::checkout/success.phtml" cacheable="false" />
+            <block class="Qbo\PayPalMX\Block\Checkout\Success" name="paypal.success.additional" template="Qbo_PayPalMX::checkout/success.phtml" cacheable="false" />
         </referenceContainer>
     </body>
 </page>

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -1,8 +1,8 @@
 var config = {
     map: {
         '*': {
-            'Magento_Paypal/js/view/payment/method-renderer/paypal-express':'qbo_PayPalMX/js/view/payment/method-renderer/paypal-express',
-            'Magento_Paypal/js/view/payment/method-renderer/in-context/checkout-express':'qbo_PayPalMX/js/view/payment/method-renderer/in-context/checkout-express'
+            'Magento_Paypal/js/view/payment/method-renderer/paypal-express':'Qbo_PayPalMX/js/view/payment/method-renderer/paypal-express',
+            'Magento_Paypal/js/view/payment/method-renderer/in-context/checkout-express':'Qbo_PayPalMX/js/view/payment/method-renderer/in-context/checkout-express'
         }
     }
 };

--- a/view/frontend/templates/express/in-context/shortcut/button.phtml
+++ b/view/frontend/templates/express/in-context/shortcut/button.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-use qbo\PayPalMX\Block\Express\InContext\Minicart\Button;
+use Qbo\PayPalMX\Block\Express\InContext\Minicart\Button;
 
 /**
  * @var \Magento\Paypal\Block\Express\InContext\Minicart\Button $block

--- a/view/frontend/web/js/view/payment/method-renderer/in-context/checkout-express.js
+++ b/view/frontend/web/js/view/payment/method-renderer/in-context/checkout-express.js
@@ -34,7 +34,7 @@ define(
         'use strict';
         return Component.extend({
             defaults: {
-                template: 'qbo_PayPalMX/payment/paypal-express-in-context',
+                template: 'Qbo_PayPalMX/payment/paypal-express-in-context',
                 clientConfig: {
                     /**
                      * @param {Object} event

--- a/view/frontend/web/js/view/payment/method-renderer/paypal-express.js
+++ b/view/frontend/web/js/view/payment/method-renderer/paypal-express.js
@@ -17,7 +17,7 @@ define(
         // data = {};
         return Component.extend({
             defaults: {
-                template: 'qbo_PayPalMX/payment/paypal-express'
+                template: 'Qbo_PayPalMX/payment/paypal-express'
             },
             id: null,
 


### PR DESCRIPTION
Since Magento 2.2 a validation on block class names is made on layout files (see magento/magento2#11110). So I'm updating the namespace and the vendor name from qbo* to Qbo* where needed. 
It works on new installs, but haven't test it on updates.